### PR TITLE
Updated to Spigot 1.19.4 and Fixed ClassCastException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ target/
 lib/
 out/
 *.iml
+.classpath
+.project
+.settings/org.eclipse.core.resources.prefs
+.settings/org.eclipse.jdt.core.prefs
+.settings/org.eclipse.m2e.core.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.19.4-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.19-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.19.4-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/net/shortninja/staffplus/core/application/config/migrators/StaffCustomModulesItemMigrator.java
+++ b/src/main/java/net/shortninja/staffplus/core/application/config/migrators/StaffCustomModulesItemMigrator.java
@@ -1,11 +1,11 @@
 package net.shortninja.staffplus.core.application.config.migrators;
 
 import be.garagepoort.mcioc.configuration.files.ConfigurationFile;
+import be.garagepoort.mcioc.configuration.yaml.configuration.MemorySection;
 import be.garagepoort.mcioc.configuration.yaml.configuration.file.FileConfiguration;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 public class StaffCustomModulesItemMigrator implements StaffPlusPlusConfigMigrator {
@@ -17,17 +17,17 @@ public class StaffCustomModulesItemMigrator implements StaffPlusPlusConfigMigrat
 
     private void migrateModules(List<ConfigurationFile> configs, String identifier, String path) {
         FileConfiguration customModulesConfig = getConfig(configs, identifier);
-        List<LinkedHashMap<String, Object>> modules = (List<LinkedHashMap<String, Object>>) customModulesConfig.getList(path, new ArrayList<>());
-        modules.forEach(map -> {
-            if (map.get("item") instanceof String) {
-                HashMap<String, String> value = new HashMap<>();
-                value.put("type", (String) map.get("item"));
-                value.put("name", (String) map.get("name"));
-                value.put("lore", (String) map.get("lore"));
-                map.put("item", value);
-                map.remove("lore");
-            }
-        });
-        customModulesConfig.set(path, modules);
+		List<MemorySection> modules = (List<MemorySection>) customModulesConfig.getList(path, new ArrayList<>());
+		modules.forEach(section -> {
+			if (section.get("item") instanceof String) {
+				HashMap<String, String> value = new HashMap<>();
+				value.put("type", section.getString("item"));
+				value.put("name", section.getString("name"));
+				value.put("lore", section.getString("lore"));
+				section.set("item", value);
+				section.set("lore", null);
+			}
+		});
+		customModulesConfig.set(path, modules);
     }
 }


### PR DESCRIPTION
There was a slight issue with a ClassCastException at `StaffCustomModulesItemMigrator:21`. I fixed this issue and changed the API version to 1.19.4.

Didn't mean to commit the .gitignore file. I know the haters out there will be mad at me for including entries for Eclipse projects 😛