### PR TITLE
1.21 Support & minor improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.20.0-SNAPSHOT</version>
+    <version>1.21.0-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.20.6-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
-            <version>1.20.6</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitAPI</artifactId>
-            <version>1.20.6</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/listeners/ModeAdvancementListener.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/listeners/ModeAdvancementListener.java
@@ -1,0 +1,48 @@
+package net.shortninja.staffplus.core.domain.staff.mode;
+
+import be.garagepoort.mcioc.tubingbukkit.annotations.IocBukkitListener;
+import net.shortninja.staffplus.core.StaffPlusPlus;
+import net.shortninja.staffplus.core.application.session.OnlinePlayerSession;
+import net.shortninja.staffplus.core.application.session.OnlineSessionsManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.GameRule;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+@IocBukkitListener
+public class ModeAdvancementListener implements Listener {
+    private final OnlineSessionsManager sessionManager;
+
+    public ModeAdvancementListener(OnlineSessionsManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onAdvancementCompleted(PlayerAdvancementDoneEvent event)  {
+        Player player = event.getPlayer();
+        OnlinePlayerSession session = sessionManager.get(player);
+        
+        if (!session.isInStaffMode()) return;
+        
+        Advancement advancement = event.getAdvancement();
+        
+        // There is no better way to do it than to disable the gamerule and then enable it
+        player.getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
+        
+        for (String criteria : advancement.getCriteria()) {
+            player.getAdvancementProgress(advancement).revokeCriteria(criteria);
+        }
+        
+        // Enable gamerule after the event
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                player.getWorld().setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, true);
+            }
+        }.runTask(StaffPlusPlus.get());
+    }
+}

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/listeners/ModeRecipeUnlockListener.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/listeners/ModeRecipeUnlockListener.java
@@ -1,0 +1,29 @@
+package net.shortninja.staffplus.core.domain.staff.mode;
+
+import be.garagepoort.mcioc.tubingbukkit.annotations.IocBukkitListener;
+import net.shortninja.staffplus.core.application.session.OnlinePlayerSession;
+import net.shortninja.staffplus.core.application.session.OnlineSessionsManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerRecipeDiscoverEvent;
+
+@IocBukkitListener
+public class ModeRecipeUnlockListener implements Listener {
+    private final OnlineSessionsManager sessionManager;
+
+    public ModeRecipeUnlockListener(OnlineSessionsManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onRecipeUnlock(PlayerRecipeDiscoverEvent event)  {
+        Player player = event.getPlayer();
+        OnlinePlayerSession session = sessionManager.get(player);
+        
+        if (!session.isInStaffMode()) return;
+        
+        event.setCancelled(true);
+    }
+}


### PR DESCRIPTION
Support for 1.21 minecraft and minor improvements

## 1.21
- [x] Bumps craftbukkit compatibility to `1.21`
- [x] Bump spigot to `1.21`

## Improvements
- [x] Make the server not award advancements in staff mode (before it could broadcast an advancements message when the user was vanished)
- [x] Make the server not award recipes in staff mode

As always, requires garagepoort/staffplusplus-craftbukkit-compatibility#5 to be merged