### PR TITLE
1.21 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.21-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
-            <version>1.21.0</version>
+            <version>1.21.1</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.21.0-SNAPSHOT</version>
+    <version>1.21.7-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/listeners/CancelWhisperToVanished.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/listeners/CancelWhisperToVanished.java
@@ -32,7 +32,7 @@ public class CancelWhisperToVanished implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void interceptCommands(PlayerCommandPreprocessEvent event) {
         String command = event.getMessage().toLowerCase();
-        if(!command.startsWith("/msg ") && !command.startsWith("/tell ")) {
+        if(!command.startsWith("/msg ") && !command.startsWith("/tell ") && !command.startsWith("/w ")) {
             return;
         }
 

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/listeners/ExperienceTargetListener.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/listeners/ExperienceTargetListener.java
@@ -1,0 +1,36 @@
+package net.shortninja.staffplus.core.domain.staff.vanish.listeners;
+
+import be.garagepoort.mcioc.tubingbukkit.annotations.IocBukkitListener;
+import net.shortninja.staffplus.core.application.session.OnlinePlayerSession;
+import net.shortninja.staffplus.core.application.session.OnlineSessionsManager;
+import net.shortninja.staffplusplus.vanish.VanishType;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+
+@IocBukkitListener(conditionalOnProperty = "vanish-module.enabled=true")
+public class ExperienceTargetListener implements Listener {
+    private final OnlineSessionsManager sessionManager;
+
+    public ExperienceTargetListener(OnlineSessionsManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+    
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onExperienceOrbTarget(EntityTargetLivingEntityEvent event) {
+        if (event.getTarget() == null || !(event.getTarget() instanceof Player) || !sessionManager.has(event.getTarget().getUniqueId()) || !(event.getEntity() instanceof ExperienceOrb)) return;
+        
+        OnlinePlayerSession session = sessionManager.get((Player) event.getTarget());
+        if (session.getVanishType() == VanishType.TOTAL || session.getVanishType() == VanishType.PLAYER) {
+            event.setCancelled(true);
+            event.setTarget(null);
+            
+            // The player can still pickup the orb, the only way to prevent it is to patch nms
+            // As a workaround, we just kill the orb
+            event.getEntity().remove();
+        }
+    }
+}


### PR DESCRIPTION
- [x] Bump protocol dependency
- [x] Make xp orbs not move to vanished players (it is not possible to use the spigot api to block orb pickup events, so we have to kill the orb to not reveal the location of a vanished player)
- [x] Bump version

Requires https://github.com/garagepoort/staffplusplus-craftbukkit-compatibility/pull/6 to be merged before this one!