### PR TITLE
Validate user input in chat channel commands

### DIFF
--- a/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/ChatChannelService.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/ChatChannelService.java
@@ -40,15 +40,15 @@ public class ChatChannelService {
     }
 
     public void sendOnChannel(SppInteractor sender, String channelId, String message, ChatChannelType type) {
-        ChatChannel channel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("Chat channel not found"));
+        ChatChannel channel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&cChat channel not found"));
         if (!channel.hasMember(sender)) {
-            throw new BusinessException("You are not a member of this channel");
+            throw new BusinessException("&cYou are not a member of this channel");
         }
         sendEvent(new ChatChannelMessageSendEvent(sender, message, channel));
     }
 
     public void closeChannel(String channelId, ChatChannelType type) {
-        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("Chat channel not found"));
+        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&cChat channel not found"));
         chatChannelRepository.delete(chatChannel.getId());
         CHAT_CHANNELS_CACHE.removeIf(c -> c.getId() == chatChannel.getId());
         sendEvent(new ChatChannelClosedEvent(chatChannel));
@@ -57,7 +57,7 @@ public class ChatChannelService {
     public void create(String channelId, String chatChannelPrefix, String chatChannelLine, String openingMessage, Set<UUID> members, ChatChannelType type) {
         Optional<ChatChannel> existingChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type));
         if (existingChannel.isPresent()) {
-            throw new BusinessException("Cannot open chat channel. This channel has already been opened");
+            throw new BusinessException("&cCannot open chat channel. This channel has already been opened");
         }
 
         ChatChannel channel = new ChatChannel(chatChannelPrefix, chatChannelLine, channelId, members, type, options.serverName);
@@ -73,9 +73,9 @@ public class ChatChannelService {
     }
 
     public void joinChannel(SppPlayer player, String channelId, ChatChannelType type) {
-        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&CChat channel not found"));
+        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&cChat channel not found"));
         if (chatChannel.hasMember(player)) {
-            throw new BusinessException("&CYou are already a member of this channel");
+            throw new BusinessException("&cYou are already a member of this channel");
         }
         chatChannel.addMember(player.getId());
         chatChannelRepository.addMember(chatChannel, player);
@@ -84,9 +84,9 @@ public class ChatChannelService {
     }
 
     public void leaveChannel(SppPlayer player, String channelId, ChatChannelType type) {
-        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&CChat channel not found"));
+        ChatChannel chatChannel = chatChannelRepository.findChatChannel(channelId, type, getSyncConfig(type)).orElseThrow(() -> new BusinessException("&cChat channel not found"));
         if (!chatChannel.hasMember(player)) {
-            throw new BusinessException("&CYou are not a member of this channel");
+            throw new BusinessException("&cYou are not a member of this channel");
         }
         chatChannel.removeMember(player.getId());
         chatChannelRepository.removeMember(chatChannel, player);

--- a/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/CloseChatChannelCmd.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/CloseChatChannelCmd.java
@@ -10,6 +10,7 @@ import net.shortninja.staffplus.core.common.cmd.CommandService;
 import net.shortninja.staffplus.core.common.cmd.SppCommand;
 import net.shortninja.staffplus.core.common.permissions.PermissionHandler;
 import net.shortninja.staffplus.core.common.utils.BukkitUtils;
+import net.shortninja.staffplus.core.common.exceptions.BusinessException;
 import net.shortninja.staffplus.core.domain.chatchannels.ChatChannelService;
 import net.shortninja.staffplusplus.chatchannels.ChatChannelType;
 import net.shortninja.staffplusplus.session.SppPlayer;
@@ -53,8 +54,19 @@ public class CloseChatChannelCmd extends AbstractCmd {
     @Override
     protected boolean executeCmd(CommandSender sender, String alias, String[] args, SppPlayer player, Map<String, String> optionalParameters) {
         String[] split = args[0].split("_");
-        ChatChannelType chatChannelType = ChatChannelType.valueOf(split[0]);
+        
+        if (split.length != 2) {
+            throw new BusinessException("&CChat channel not found");
+        }
+        
+        ChatChannelType chatChannelType;
+        try {
+            chatChannelType = ChatChannelType.valueOf(split[0]);
+        } catch (IllegalArgumentException ignored) {
+            throw new BusinessException("&CChat channel not found");
+        }
         String chatChannelId = split[1];
+        
         permissionHandler.validate(sender, closePermission + "." + chatChannelType.name().toLowerCase());
         bukkitUtils.runTaskAsync(sender, () -> chatChannelService.closeChannel(chatChannelId, chatChannelType));
         return true;

--- a/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/JoinChatChannelCmd.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/JoinChatChannelCmd.java
@@ -58,7 +58,7 @@ public class JoinChatChannelCmd extends AbstractCmd {
     protected boolean executeCmd(CommandSender sender, String alias, String[] args, SppPlayer player, Map<String, String> optionalParameters) {
         String[] split = args[0].split("_");
         
-        if (split.length < 2) {
+        if (split.length != 2) {
             throw new BusinessException("&CChat channel not found");
         }
         

--- a/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/LeaveChatChannelCmd.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/chatchannels/gui/LeaveChatChannelCmd.java
@@ -10,6 +10,7 @@ import net.shortninja.staffplus.core.common.cmd.CommandService;
 import net.shortninja.staffplus.core.common.cmd.SppCommand;
 import net.shortninja.staffplus.core.common.permissions.PermissionHandler;
 import net.shortninja.staffplus.core.common.utils.BukkitUtils;
+import net.shortninja.staffplus.core.common.exceptions.BusinessException;
 import net.shortninja.staffplus.core.domain.chatchannels.ChatChannelService;
 import net.shortninja.staffplus.core.domain.player.PlayerManager;
 import net.shortninja.staffplusplus.chatchannels.ChatChannelType;
@@ -56,7 +57,17 @@ public class LeaveChatChannelCmd extends AbstractCmd {
     @Override
     protected boolean executeCmd(CommandSender sender, String alias, String[] args, SppPlayer player, Map<String, String> optionalParameters) {
         String[] split = args[0].split("_");
-        ChatChannelType chatChannelType = ChatChannelType.valueOf(split[0]);
+        
+        if (split.length != 2) {
+            throw new BusinessException("&CChat channel not found");
+        }
+        
+        ChatChannelType chatChannelType;
+        try {
+            chatChannelType = ChatChannelType.valueOf(split[0]);
+        } catch (IllegalArgumentException ignored) {
+            throw new BusinessException("&CChat channel not found");
+        }
         String chatChannelId = split[1];
 
         permissionHandler.validate(sender, leavePermission + "." + chatChannelType.name().toLowerCase());


### PR DESCRIPTION
Ensures that:
- [x] User input has exactly 1 underscore
- [x] The channel type is a valid type 

Fixes #247