### PR TITLE
Translation of GUI Titles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.21.7-SNAPSHOT</version>
+    <version>1.21.8-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/mute/gui/MuteGuiController.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/mute/gui/MuteGuiController.java
@@ -1,5 +1,6 @@
 package net.shortninja.staffplus.core.domain.staff.mute.gui;
 
+import be.garagepoort.mcioc.configuration.ConfigProperty;
 import be.garagepoort.mcioc.tubinggui.AsyncGui;
 import be.garagepoort.mcioc.tubinggui.GuiAction;
 import be.garagepoort.mcioc.tubinggui.GuiController;
@@ -37,6 +38,9 @@ public class MuteGuiController {
     private final BukkitUtils bukkitUtils;
     private final PlayerManager playerManager;
     private final MuteRepository muteRepository;
+    
+    @ConfigProperty("%lang%:gui.mutes.my-mutes.title")
+    private String myMytesGuiTitle;
 
     public MuteGuiController(Messages messages,
                              MuteService muteService,
@@ -77,7 +81,7 @@ public class MuteGuiController {
         return async(() -> {
             List<Mute> allPaged = muteRepository.getMyMutes(player.getUniqueId(), page * PAGE_SIZE, PAGE_SIZE);
             Map<String, Object> params = new HashMap<>();
-            params.put("title", "&bMy mutes");
+            params.put("title", myMytesGuiTitle);
             params.put("mutes", allPaged);
             params.put("guiId", "my-mutes-overview");
             return template("gui/mutes/mute-overview.ftl", params);

--- a/src/main/resources/gui/warnings/my-warnings-overview.ftl
+++ b/src/main/resources/gui/warnings/my-warnings-overview.ftl
@@ -1,8 +1,9 @@
 <#import "warning-commons.ftl" as warningCommons/>
 <#import "/gui/commons/commons.ftl" as commons/>
+<#include "/gui/commons/translate.ftl"/>
 <#assign URLEncoder=statics['java.net.URLEncoder']>
 <TubingGui size="54" id="my-warnings-overview">
-    <title class="gui-title">My Warnings</title>
+    <title class="gui-title"><@translate key="gui.warnings.my-warnings.title"/></title>
 
     <#list warnings as warning>
         <GuiItem id="warning-info-${warning?index}"

--- a/src/main/resources/lang/lang_de.yml
+++ b/src/main/resources/lang/lang_de.yml
@@ -414,6 +414,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMeine Stummschaltungen"
     warnings:
         appeal-detail:
             approve:
@@ -422,6 +424,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMeine Warnungen"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_en.yml
+++ b/src/main/resources/lang/lang_en.yml
@@ -413,6 +413,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMy mutes"
     warnings:
         appeal-detail:
             approve:
@@ -421,6 +423,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMy warnings"
     reports:
         report: "Report"
         assignee: "Assignee"
@@ -448,7 +452,7 @@ gui:
             right-click-to-resolve: "&7Right click to &2resolve"
             left-shift-click-to-reject: "&7Left shift click to &Creject"
         my-reports:
-            title: "My reports"
+            title: "&bMy reports"
         open-reports:
             title: "Open reports"
             left-click-to-accept: "&7Left click to &6accept"

--- a/src/main/resources/lang/lang_es.yml
+++ b/src/main/resources/lang/lang_es.yml
@@ -425,6 +425,8 @@ gui:
             reject:
                 title: "Rechazar apelación"
                 lore: "Clic para rechazar esta apelación"
+        my-mutes:
+            title: "&bMis silencios"
     warnings:
         appeal-detail:
             approve:
@@ -433,6 +435,8 @@ gui:
             reject:
                 title: "Rechazar apelación"
                 lore: "Clic para rechazar esta apelación"
+        my-warnings:
+            title: "&bMis advertencias"
     reports:
         report: "Reporte"
         assignee: "Asignado"

--- a/src/main/resources/lang/lang_fr.yml
+++ b/src/main/resources/lang/lang_fr.yml
@@ -413,6 +413,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMes mutes"
     warnings:
         appeal-detail:
             approve:
@@ -421,6 +423,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMes avertissements"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_hr.yml
+++ b/src/main/resources/lang/lang_hr.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMoje isključenja zvuka"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMoja upozorenja"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_hu.yml
+++ b/src/main/resources/lang/lang_hu.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bNémításaim"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bFigyelmeztetéseim"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_id.yml
+++ b/src/main/resources/lang/lang_id.yml
@@ -412,6 +412,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bPembisuan saya"
     warnings:
         appeal-detail:
             approve:
@@ -420,6 +422,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bPeringatan saya"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_it.yml
+++ b/src/main/resources/lang/lang_it.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bI miei mutes"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bI miei avvisi"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_lt.yml
+++ b/src/main/resources/lang/lang_lt.yml
@@ -296,6 +296,8 @@ gui:
             reject:
                 title: Atmesti Prašyma
                 lore: Spauskite, kad atmestumete prašyma
+        my-mutes:
+            title: "&bMano nutildymai"
     warnings:
         appeal-detail:
             approve:
@@ -304,6 +306,8 @@ gui:
             reject:
                 title: Atmesti Prašyma
                 lore: Spauskite, kad atmestumete prašyma
+        my-warnings:
+            title: "&bMano įspėjimai"
     reports:
         report: Pranešimas
         assignee: Perėmėjas

--- a/src/main/resources/lang/lang_nl.yml
+++ b/src/main/resources/lang/lang_nl.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMijn mutes"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMijn waarschuwingen"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_no.yml
+++ b/src/main/resources/lang/lang_no.yml
@@ -410,6 +410,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMine dempinger"
     warnings:
         appeal-detail:
             approve:
@@ -418,6 +420,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMine advarsler"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_pl.yml
+++ b/src/main/resources/lang/lang_pl.yml
@@ -413,6 +413,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Kliknij, aby odrzucić apelację"
+        my-mutes:
+            title: "&bMoje wyciszenia"
     warnings:
         appeal-detail:
             approve:
@@ -421,6 +423,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Kliknij, aby odrzucić apelację"
+        my-warnings:
+            title: "&bMoje ostrzeżenia"
     reports:
         report: "Zgłoszenie"
         assignee: "Osoba przydzielona"

--- a/src/main/resources/lang/lang_pt.yml
+++ b/src/main/resources/lang/lang_pt.yml
@@ -410,6 +410,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-mutes:
+            title: "&bMeus silenciamentos"
     warnings:
         appeal-detail:
             approve:
@@ -418,6 +420,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMinhas advertências"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_ru.yml
+++ b/src/main/resources/lang/lang_ru.yml
@@ -311,6 +311,8 @@ gui:
       reject:
         title: Отклонить обращение
         lore: Нажмите, чтобы отклонить это обращение
+    my-mutes:
+      title: "&bМои отключения звука"
   warnings:
     appeal-detail:
       approve:
@@ -319,6 +321,8 @@ gui:
       reject:
         title: Отклонить обращение
         lore: Нажмите, чтобы отклонить это обращение
+    my-warnings:
+            title: "&bМои предупреждения"
   reports:
     report: Жалоба
     assignee: Получатель

--- a/src/main/resources/lang/lang_sv.yml
+++ b/src/main/resources/lang/lang_sv.yml
@@ -411,7 +411,7 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
-         my-mutes:
+        my-mutes:
             title: "&bMina tystningar"
     warnings:
         appeal-detail:

--- a/src/main/resources/lang/lang_sv.yml
+++ b/src/main/resources/lang/lang_sv.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+         my-mutes:
+            title: "&bMina tystningar"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&bMina varningar"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_zh.yml
+++ b/src/main/resources/lang/lang_zh.yml
@@ -411,6 +411,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+         my-mutes:
+            title: "&b我的静音"
     warnings:
         appeal-detail:
             approve:
@@ -419,6 +421,8 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
+        my-warnings:
+            title: "&b我的警告"
     reports:
         report: "Report"
         assignee: "Assignee"

--- a/src/main/resources/lang/lang_zh.yml
+++ b/src/main/resources/lang/lang_zh.yml
@@ -411,7 +411,7 @@ gui:
             reject:
                 title: "Reject Appeal"
                 lore: "Click to reject this appeal"
-         my-mutes:
+        my-mutes:
             title: "&b我的静音"
     warnings:
         appeal-detail:

--- a/src/test/resources/guitemplates/warnings/my-warnings-overview.xml
+++ b/src/test/resources/guitemplates/warnings/my-warnings-overview.xml
@@ -1,5 +1,5 @@
 <TubingGui size="54" id="my-warnings-overview">
-    <title class="gui-title">&bMy Warnings</title>
+    <title class="gui-title">&amp;bMy warnings</title>
 
     <GuiItem id="warning-info-0" class="warning-info" slot="0" onLeftClick="manage-warnings/view/detail?warningId=12" material="PLAYER_HEAD">
         <name class="item-name" color="&amp;3">Warning</name>

--- a/src/test/resources/guitemplates/warnings/my-warnings-overview.xml
+++ b/src/test/resources/guitemplates/warnings/my-warnings-overview.xml
@@ -1,5 +1,5 @@
 <TubingGui size="54" id="my-warnings-overview">
-    <title class="gui-title">My Warnings</title>
+    <title class="gui-title">&bMy Warnings</title>
 
     <GuiItem id="warning-info-0" class="warning-info" slot="0" onLeftClick="manage-warnings/view/detail?warningId=12" material="PLAYER_HEAD">
         <name class="item-name" color="&amp;3">Warning</name>


### PR DESCRIPTION
Allows translating the GUI title of:

- [x] `/my-reports`
- [x] `/my-warnings`

Also, why do we have files for  some languages (such as `lang_de.yml`) which is only English?

I used ChatGPT to translate to all other languages, apart from English.

Done for the request of bixelcraft on discord.