### PR TITLE
1.21.1 Paper Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
                 <artifactId>item-nbt-api</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>


### PR DESCRIPTION
Adds support fix for 1.21.1 paper, which currently crashes when viewing some inventories, such as enderchests of offline players.

Steps to reproduce error (only on paper):
- Log in with Player1
- Login with Staff1
- Leave with Player1
- Run `/eview Player1`
- Observe entire server crash

Issue was that I did not bump the nbt-api, which our version did not have support for paper 1.21.1.