### PR TITLE
1.21.2 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21.3-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -65,17 +65,17 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
                 <artifactId>item-nbt-api</artifactId>
-            <version>2.13.2</version>
+            <version>2.14</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
-            <version>1.21.1</version>
+            <version>1.21.2</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitAPI</artifactId>
-            <version>1.21.1</version>
+            <version>1.21.2</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
                 <artifactId>item-nbt-api</artifactId>
-            <version>2.14</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.21.8-SNAPSHOT</version>
+    <version>1.21.10-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>

--- a/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
+++ b/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
@@ -75,9 +75,15 @@ public class JavaUtils {
         try {
             Enum.valueOf(enumClass, enumName);
             return true;
-        } catch (IllegalArgumentException ex) {
-            return false;
-        }
+        } catch (IllegalArgumentException ignored) {}
+        
+        // Bukkit started migrating some enums to interfaces breaking our implementation, so we check for class values too
+        try {
+            enumClass.getDeclaredField(enumName);
+            return true;
+        } catch (NoSuchFieldException ignored) {}
+        
+        return false;
     }
 
     public static long getDuration(long timestamp) {

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/cmd/HealthArgumentExecutor.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/mode/cmd/HealthArgumentExecutor.java
@@ -24,7 +24,7 @@ public class HealthArgumentExecutor implements ArgumentExecutor {
             return false;
         }
 
-        AttributeInstance attribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
         double maxHealth = attribute.getValue();
         if(value.isEmpty()) {
             player.setHealth(maxHealth);

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 plugin.version=${project.version}
 java.version=${maven.compiler.source}
-mc.version=1.20.6
+mc.version=1.21.3

--- a/src/test/java/net/shortninja/staffplus/core/RunPluginIT.java
+++ b/src/test/java/net/shortninja/staffplus/core/RunPluginIT.java
@@ -98,7 +98,7 @@ public class RunPluginIT {
                         .run("mkdir", "plugins/StaffPlusPlus")
                         .copy("staffplusplus-core-" + implementationVersion + ".jar", "/plugins")
                         .copy("config.yml", "/plugins/StaffPlusPlus")
-                        .cmd("java", "-jar", "spigot-" + mcVersion + ".jar", "nogui")
+                        .cmd("java", "-jar", "-DIReallyKnowWhatIAmDoingISwear", "spigot-" + mcVersion + ".jar", "--nogui")
                         .build()))
             .waitingFor(Wait.forLogMessage(".*Done.*", 1))
             .withStartupTimeout(Duration.ofSeconds(360))


### PR DESCRIPTION
Changes:

- [x] Add support for `1.21.2` and `1.21.3`

**Requires** https://github.com/garagepoort/staffplusplus-craftbukkit-compatibility/pull/8