### PR TITLE
Add 1.21.4 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.21.3-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21.4-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
-            <version>1.21.2</version>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitAPI</artifactId>
-            <version>1.21.2</version>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         </dependency>
         <dependency>
             <groupId>de.tr7zw</groupId>
-                <artifactId>item-nbt-api</artifactId>
-            <version>2.14.0</version>
+            <artifactId>item-nbt-api</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.21.10-SNAPSHOT</version>
+    <version>1.21.11-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>


### PR DESCRIPTION
Adds support for 1.21.4 minecraft version.

Needs https://github.com/garagepoort/staffplusplus-craftbukkit-compatibility/pull/10 merged before this.

This does not address in anyway the paper hardfork changes, however I can think of two possible options of doing this:
- Do not make any changes, and test on paper to ensure we don't use apis that paper no longer pulled in
- Build against the paper apis, but make sure to not use any `io.papermc` code (as that will not run on pure spigot)