### PR TITLE
Add 26.1.x support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>
-        <spigot.version>1.21.11-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>26.1.2-R0.1-SNAPSHOT</spigot.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -65,17 +65,17 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.15.5</version>
+            <version>2.15.7</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
-            <version>1.21.10</version>
+            <version>26.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.shortninja.staffplus</groupId>
             <artifactId>StaffPlusPlusCraftbukkitAPI</artifactId>
-            <version>1.21.10</version>
+            <version>26.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.shortninja.staffplus</groupId>
     <name>Staff++</name>
     <description>The ultimate moderation plugin.</description>
-    <version>1.21.18-SNAPSHOT</version>
+    <version>26.1.0-SNAPSHOT</version>
     <artifactId>staffplusplus-core</artifactId>
 
     <properties>

--- a/src/main/java/net/shortninja/staffplus/core/application/config/Options.java
+++ b/src/main/java/net/shortninja/staffplus/core/application/config/Options.java
@@ -71,15 +71,14 @@ public class Options {
     }
 
     public static Material stringToMaterial(String string) {
-        Material sound = Material.STONE;
+        String materialName = getMaterial(string);
 
-        boolean isValid = JavaUtils.isValidEnum(Material.class, getMaterial(string));
-        if (!isValid) {
+        if (!JavaUtils.isValidEnum(Material.class, materialName)) {
             Bukkit.getLogger().severe("Invalid material type '" + string + "'!");
-        } else
-            sound = Material.valueOf(getMaterial(string));
+            return Material.STONE;
+        }
 
-        return sound;
+        return Material.valueOf(materialName);
     }
 
     public static String sanitizeMaterial(String string) {

--- a/src/main/java/net/shortninja/staffplus/core/common/BukkitInventorySerialization.java
+++ b/src/main/java/net/shortninja/staffplus/core/common/BukkitInventorySerialization.java
@@ -6,11 +6,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.util.io.BukkitObjectInputStream;
 import org.bukkit.util.io.BukkitObjectOutputStream;
-import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
 
 public class BukkitInventorySerialization {
     /**
@@ -54,7 +54,7 @@ public class BukkitInventorySerialization {
 
             // Serialize that array
             dataOutput.close();
-            return Base64Coder.encodeLines(outputStream.toByteArray());
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
         } catch (Exception e) {
             throw new IllegalStateException("Unable to save item stacks.", e);
         }
@@ -89,7 +89,7 @@ public class BukkitInventorySerialization {
 
             // Serialize that array
             dataOutput.close();
-            return Base64Coder.encodeLines(outputStream.toByteArray());
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
         } catch (Exception e) {
             throw new IllegalStateException("Unable to save item stacks.", e);
         }
@@ -111,7 +111,7 @@ public class BukkitInventorySerialization {
      */
     public static Inventory fromBase64(String data) throws IOException {
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getMimeDecoder().decode(data));
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
             Inventory inventory = Bukkit.getServer().createInventory(null, dataInput.readInt());
 
@@ -140,7 +140,7 @@ public class BukkitInventorySerialization {
      */
     public static ItemStack[] itemStackArrayFromBase64(String data) throws IOException {
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getMimeDecoder().decode(data));
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
             ItemStack[] items = new ItemStack[dataInput.readInt()];
 

--- a/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
+++ b/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
@@ -15,6 +15,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.util.Vector;
 
+import java.lang.ReflectiveOperationException;
+import java.lang.reflect.Method;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +36,8 @@ public class JavaUtils {
     private static final List<TimeUnit> timeUnits = Arrays.asList(TimeUnit.DAYS, TimeUnit.HOURS, TimeUnit.MINUTES, TimeUnit.SECONDS);
     private static final String DEFAULT_MESSAGE_COLOR = "&6";
     private static final String DEFAULT_CLICK_MESSAGE_COLOR = "&9";
+    
+    private static int[] serverVersion;
 
     public static String toHumanReadableDuration(final long millis) {
         if (millis <= 0) {
@@ -267,18 +271,50 @@ public class JavaUtils {
      * @return serverVersion >= (major, minor, patch)
      */
     public static boolean isMcVerGreaterOrEqual(int major, int minor, int patch) {
-        String[] cVersion = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
-        int cMajor = Integer.parseInt(cVersion[0]);
-        int cMinor = Integer.parseInt(cVersion[1]);
-        int cPatch = cVersion.length > 2 ? Integer.parseInt(cVersion[2]) : 0;
+        int[] version = getServerVersion();
+        if (version[0] != major) {
+            return version[0] > major;
+        }
         
-        if (cMajor > major) return true;
-        if (cMajor < major) return false;
+        if (version[1] != minor) {
+            return version[1] > minor;
+        }
         
-        if (cMinor > minor) return true;
-        if (cMinor < minor) return false;
+        return version[2] >= patch;
+    }
+    
+    private static int[] getServerVersion() {
+        if (serverVersion == null) {
+            serverVersion = parseServerVersion();
+        }
+        return serverVersion;
+    }
+    
+    private static int[] parseServerVersion() {
+        // Paper's implementation of Bukkit.getBukkitVersion() returns a different format than spigot
+        // this method attempts to use paper API to get the server version if paper is found
+        // otherwise fallbacks to parsing Bukkit.getBukkitVersion(), with the assumption that the server is not paper
         
-        return cPatch >= patch;
+        String rawVersion;
+        try {
+            Class<?> clazz = Class.forName("io.papermc.paper.ServerBuildInfo");
+
+            Method buildInfo = clazz.getMethod("buildInfo");
+            Object info = buildInfo.invoke(null); // static
+
+            Method minecraftVersionId = clazz.getMethod("minecraftVersionId");
+            rawVersion = (String) minecraftVersionId.invoke(info);
+        } catch (ReflectiveOperationException ignored) {
+            rawVersion = Bukkit.getBukkitVersion();
+        }
+
+        String[] parts = rawVersion.split("-")[0].split("\\.");
+
+        return new int[] {
+                Integer.parseInt(parts[0]),
+                Integer.parseInt(parts[1]),
+                parts.length > 2 ? Integer.parseInt(parts[2]) : 0
+        };
     }
 
     /**

--- a/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
+++ b/src/main/java/net/shortninja/staffplus/core/common/JavaUtils.java
@@ -259,13 +259,26 @@ public class JavaUtils {
     }
 
     /**
-     * Parses a mc version and returns what the main version is
+     * Checks if the server mc version is greater or equal to the supplied mc version
      *
-     * @param ver Version string to be parsed.
-     * @return Second number of the version i.e 13.
+     * @param major Major component of the version to compare
+     * @param minor Minor component of the version to compare
+     * @param patch Patch component of the version to compare
+     * @return serverVersion >= (major, minor, patch)
      */
-    public static int parseMcVer(String ver) {
-        return Integer.parseInt(ver.split("\\.")[1].replaceAll("[^0-9]", ""));
+    public static boolean isMcVerGreaterOrEqual(int major, int minor, int patch) {
+        String[] cVersion = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
+        int cMajor = Integer.parseInt(cVersion[0]);
+        int cMinor = Integer.parseInt(cVersion[1]);
+        int cPatch = cVersion.length > 2 ? Integer.parseInt(cVersion[2]) : 0;
+        
+        if (cMajor > major) return true;
+        if (cMajor < major) return false;
+        
+        if (cMinor > minor) return true;
+        if (cMinor < minor) return false;
+        
+        return cPatch >= patch;
     }
 
     /**

--- a/src/main/java/net/shortninja/staffplus/core/common/utils/Materials.java
+++ b/src/main/java/net/shortninja/staffplus/core/common/utils/Materials.java
@@ -20,12 +20,10 @@ public enum Materials {
     }
 
     public String getName() {
-        String[] tmp = Bukkit.getVersion().split("MC: ");
-        String version = tmp[tmp.length - 1].substring(0, 4);
-        int ver = JavaUtils.parseMcVer(version);
-        if(ver>=13) {
+        if (JavaUtils.isMcVerGreaterOrEqual(1, 13, 0)) {
             return newName;
-        } else
-            return oldName;
+        }
+        
+        return oldName;
     }
 }


### PR DESCRIPTION
Adds support for Minecraft versions `26.1.x`.

This also changes the version of the plugin to match Minecraft's new versioning scheme, as that is how the system worked for previous releases. If this is not desirable, it can be changed.

Requires https://github.com/garagepoort/staffplusplus-craftbukkit-compatibility/pull/15
Would recommend to merge #270 for this release, as it fixes a vanish bypass.

Fixes #271
