### PR TITLE
Replace native vanish logic with SuperVanish API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
             <id>staffplusplus-repo</id>
             <url>https://nexus.staffplusplus.org/repository/staffplusplus/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -103,6 +107,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.LeonMangler</groupId>
+            <artifactId>SuperVanish</artifactId>
+            <version>6.2.18-3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/PlayerVanishStrategy.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/PlayerVanishStrategy.java
@@ -2,6 +2,7 @@ package net.shortninja.staffplus.core.domain.staff.vanish;
 
 import be.garagepoort.mcioc.IocBean;
 import be.garagepoort.mcioc.IocMultiProvider;
+import de.myzelyam.api.vanish.VanishAPI;
 import net.shortninja.staffplus.core.application.session.OnlineSessionsManager;
 import net.shortninja.staffplus.core.common.IProtocolService;
 import net.shortninja.staffplus.core.common.permissions.PermissionHandler;
@@ -37,12 +38,13 @@ public class PlayerVanishStrategy implements VanishStrategy {
 
     @Override
     public void vanish(SppPlayer player) {
-        Bukkit.getOnlinePlayers().stream()
-            .filter(p -> !permission.has(p, vanishConfiguration.permissionSeeVanished))
-            .forEach(p -> p.hidePlayer(player.getPlayer()));
-
+        // SuperVanish handles player visibility
+        if (!VanishAPI.isInvisible(player.getPlayer())) {
+            VanishAPI.hidePlayer(player.getPlayer());
+        }
+        // Player vanish type: keep visible in tab list
         protocolService.getVersionProtocol().listVanish(player.getPlayer(), false);
-        
+
         // Cancel existing targets of mobs
         int mobActivationRange = Bukkit.getServer().spigot().getConfig().getInt("world-settings.default.entity-activation-range.monsters");
         player.getPlayer().getWorld().getNearbyEntities(player.getPlayer().getLocation(), mobActivationRange, mobActivationRange, mobActivationRange).forEach(entity -> {
@@ -55,21 +57,22 @@ public class PlayerVanishStrategy implements VanishStrategy {
 
     @Override
     public void unvanish(SppPlayer player) {
-        Bukkit.getOnlinePlayers().forEach(p -> p.showPlayer(player.getPlayer()));
+        if (VanishAPI.isInvisible(player.getPlayer())) {
+            VanishAPI.showPlayer(player.getPlayer());
+        }
     }
 
     @Override
     public void updateVanish(SppPlayer player) {
+        // SuperVanish handles forwarding vanish state to newly joined players automatically.
+        // For PLAYER type, ensure tab list remains visible for the joining player.
         if (!permission.has(player.getPlayer(), vanishConfiguration.permissionSeeVanished)) {
             sessionManager.getAll().stream()
                 .filter(session -> session.getVanishType() == VanishType.PLAYER)
                 .map(s -> playerManager.getOnlinePlayer(s.getUuid()))
                 .flatMap(optional -> optional.map(Stream::of).orElseGet(Stream::empty))
                 .map(SppPlayer::getPlayer)
-                .forEach(p -> {
-                    player.getPlayer().hidePlayer(p.getPlayer());
-                    protocolService.getVersionProtocol().listVanish(p.getPlayer(), false);
-                });
+                .forEach(p -> protocolService.getVersionProtocol().listVanish(p.getPlayer(), false));
         }
     }
 

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/TotalVanishStrategy.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/TotalVanishStrategy.java
@@ -2,6 +2,7 @@ package net.shortninja.staffplus.core.domain.staff.vanish;
 
 import be.garagepoort.mcioc.IocBean;
 import be.garagepoort.mcioc.IocMultiProvider;
+import de.myzelyam.api.vanish.VanishAPI;
 import net.shortninja.staffplus.core.application.session.OnlineSessionsManager;
 import net.shortninja.staffplus.core.common.IProtocolService;
 import net.shortninja.staffplus.core.common.permissions.PermissionHandler;
@@ -37,11 +38,12 @@ public class TotalVanishStrategy implements VanishStrategy {
 
     @Override
     public void vanish(SppPlayer player) {
-        Bukkit.getOnlinePlayers().stream()
-            .filter(p -> !permission.has(p, vanishConfiguration.permissionSeeVanished))
-            .forEach(p -> p.hidePlayer(player.getPlayer()));
+        // SuperVanish handles player visibility and tab list hiding
+        if (!VanishAPI.isInvisible(player.getPlayer())) {
+            VanishAPI.hidePlayer(player.getPlayer());
+        }
         listVanish(player, true);
-        
+
         // Cancel existing targets of mobs
         int mobActivationRange = Bukkit.getServer().spigot().getConfig().getInt("world-settings.default.entity-activation-range.monsters");
         player.getPlayer().getWorld().getNearbyEntities(player.getPlayer().getLocation(), mobActivationRange, mobActivationRange, mobActivationRange).forEach(entity -> {
@@ -54,16 +56,15 @@ public class TotalVanishStrategy implements VanishStrategy {
 
     @Override
     public void updateVanish(SppPlayer player) {
+        // SuperVanish handles forwarding vanish state to newly joined players automatically.
+        // Still apply tab list hiding for players who shouldn't see vanished staff.
         if (!permission.has(player.getPlayer(), vanishConfiguration.permissionSeeVanished)) {
             sessionManager.getAll().stream()
                 .filter(s -> s.getVanishType() == VanishType.TOTAL)
                 .map(s -> playerManager.getOnlinePlayer(s.getUuid()))
                 .flatMap(optional -> optional.map(Stream::of).orElseGet(Stream::empty))
                 .map(SppPlayer::getPlayer)
-                .forEach(p -> {
-                    player.getPlayer().hidePlayer(p.getPlayer());
-                    listVanish(player, true);
-                });
+                .forEach(p -> listVanish(new SppPlayer(p.getUniqueId(), p.getName(), p), true));
         }
     }
 
@@ -76,7 +77,9 @@ public class TotalVanishStrategy implements VanishStrategy {
     @Override
     public void unvanish(SppPlayer player) {
         listVanish(player, false);
-        Bukkit.getOnlinePlayers().forEach(p -> p.showPlayer(player.getPlayer()));
+        if (VanishAPI.isInvisible(player.getPlayer())) {
+            VanishAPI.showPlayer(player.getPlayer());
+        }
     }
 
     @Override

--- a/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/VanishService.java
+++ b/src/main/java/net/shortninja/staffplus/core/domain/staff/vanish/VanishService.java
@@ -1,11 +1,13 @@
 package net.shortninja.staffplus.core.domain.staff.vanish;
 
 import be.garagepoort.mcioc.IocBean;
+import de.myzelyam.api.vanish.VanishAPI;
 import net.shortninja.staffplus.core.domain.player.settings.PlayerSettings;
 import net.shortninja.staffplus.core.domain.player.settings.PlayerSettingsRepository;
 import net.shortninja.staffplusplus.vanish.VanishOffEvent;
 import net.shortninja.staffplusplus.vanish.VanishOnEvent;
 import net.shortninja.staffplusplus.vanish.VanishType;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -44,6 +46,15 @@ public class VanishService {
         settings.setVanishType(vanishType);
         playerSettingsRepository.save(settings);
         vanishCache.put(player.getUniqueId(), vanishType);
+
+        // Sync with SuperVanish: hide for TOTAL and PLAYER types
+        if (vanishType == VanishType.TOTAL || vanishType == VanishType.PLAYER) {
+            // Ensure the player is not already vanished before hiding
+            if (!VanishAPI.isInvisible(player)) {
+                VanishAPI.hidePlayer(player);
+            }
+        }
+
         sendEvent(new VanishOnEvent(vanishType, player, onJoin));
     }
 
@@ -57,6 +68,11 @@ public class VanishService {
         vanishCache.put(player.getUniqueId(), VanishType.NONE);
         playerSettingsRepository.save(session);
 
+        // Sync with SuperVanish: show the player
+        if (VanishAPI.isInvisible(player)) {
+            VanishAPI.showPlayer(player);
+        }
+
         sendEvent(new VanishOffEvent(vanishType, player));
     }
 
@@ -65,6 +81,11 @@ public class VanishService {
     }
 
     public boolean isVanished(Player player) {
+        // Use SuperVanish as the source of truth for TOTAL and PLAYER vanish types
+        if (VanishAPI.isInvisible(player)) {
+            return true;
+        }
+        // Fall back to PlayerSettings for LIST vanish type (which SuperVanish doesn't manage)
         PlayerSettings user = playerSettingsRepository.get(player);
         return user.getVanishType() != VanishType.NONE;
     }


### PR DESCRIPTION
Replaces StaffPlusPlus native vanish (manual Player.hidePlayer/showPlayer iteration) with SuperVanish API.

Changes:
- pom.xml: Added SuperVanish dependency via JitPack
- VanishService: Syncs with VanishAPI.hidePlayer/showPlayer/isInvisible
- TotalVanishStrategy: Delegates to VanishAPI instead of manual player iteration
- PlayerVanishStrategy: Delegates to VanishAPI + keeps tab list visible
- DiscordSRV events still fire via existing VanishOnEvent/VanishOffEvent
- ListVanishStrategy unchanged (protocol-only)